### PR TITLE
Support categories as target audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each notification banner may have the following features:
 * **Title**, optional, displayed as a H2 heading above the message
 * **Message**, 500 character long simple notification message. Markdown is supported.
 * **Audience**, select the user groups as audience for the notification.
+* **Categories**; select categories to display the banner on. Leave empty to display on all categories.
 * **Background color**, can be set to differantiate the banner from others.
 * **Plugin outlet**, set notifications above or below the site header, or use the top-notices outlet to display along with native topic banners.
 * **Display in a carousel**, when selected, all the banners in each outlet are displayed in a carousel. Requires minimum 2 banners to be selected for any outlet.

--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
   "name": "Discourse Notification Banners",
-  "theme_version": "1.1.0",
+  "theme_version": "1.1.1",
   "authors": "Osman Gormus <osman@gorm.us>",
   "component": true,
   "assets": {

--- a/about.json
+++ b/about.json
@@ -1,6 +1,6 @@
 {
   "name": "Discourse Notification Banners",
-  "theme_version": "1.0.1",
+  "theme_version": "1.1.0",
   "authors": "Osman Gormus <osman@gorm.us>",
   "component": true,
   "assets": {

--- a/javascripts/discourse/initializers/notification-banners.gjs
+++ b/javascripts/discourse/initializers/notification-banners.gjs
@@ -53,6 +53,7 @@ export default apiInitializer("1.14.0", (api) => {
 
     banner_list.forEach((BANNER, n) => {
       const banner_audience = BANNER.enabled_groups;
+      const banner_categories = BANNER.selected_categories;
       const banner_title = BANNER.title?.trim();
       const banner_message = BANNER.message.trim();
       const banner_plugin_outlet = BANNER.plugin_outlet.trim();
@@ -74,6 +75,18 @@ export default apiInitializer("1.14.0", (api) => {
             const currentRoute = this.router.currentRoute;
             // Show everywhere but admin pages.
             return !currentRoute.name.includes("admin");
+          }
+
+          get showOnCategory() {
+            if (banner_categories.length === 0) {
+              return true;
+            }
+            const currentRoute = this.router.currentRoute;
+            const category_id = currentRoute.attributes?.category?.id;
+            return (
+              currentRoute.name === "discovery.category" &&
+              banner_categories.includes(category_id)
+            );
           }
 
           get showForCurrentUser() {
@@ -130,6 +143,7 @@ export default apiInitializer("1.14.0", (api) => {
           get shouldShow() {
             return (
               this.showOnRoute &&
+              this.showOnCategory &&
               this.showForCurrentUser &&
               this.showBetweenDates &&
               !this.dismissed

--- a/javascripts/discourse/initializers/notification-banners.gjs
+++ b/javascripts/discourse/initializers/notification-banners.gjs
@@ -2,6 +2,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
+import { htmlSafe } from "@ember/template";
 import $ from "jquery";
 import CookText from "discourse/components/cook-text";
 import DButton from "discourse/components/d-button";
@@ -166,7 +167,7 @@ export default apiInitializer("1.14.0", (api) => {
                 class="notification-banner
                   {{banner_css_carousel}}
                   {{banner_plugin_outlet}}"
-                style={{this.bannerColors}}
+                style={{htmlSafe this.bannerColors}}
               >
                 <div class="notification-banner__wrapper wrap">
                   {{#if this.bannerDismissable}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -9,6 +9,9 @@ en:
             enabled_groups:
               label: Audience
               description: "Who should see this banner? Select all the user-groups as needed. At least, select \"everyone\" group."
+            selected_categories:
+              label: Categories
+              description: "Select categories to display the banner on. Leave empty to display on all categories."
             title:
               label: Title
               description: "Notification banner title, displayed in a H2 heading."

--- a/migrations/settings/0001-add-categories.js
+++ b/migrations/settings/0001-add-categories.js
@@ -1,0 +1,11 @@
+export default function migrate(settings) {
+  if (settings.has("banners")) {
+    const banners = settings.get("banners");
+    banners.forEach(banner => {
+      banner.selected_categories = [];
+    });
+
+    settings.set("banners", banners);
+  }
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -11,6 +11,8 @@ banners:
         required: true
         validations:
           min: 1
+      selected_categories:
+        type: categories
       title:
         type: string
       message:


### PR DESCRIPTION
* Adds category support
  The banners can use the selected categories as the target audience. 

* Fixes an Emberjs warning
  > Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped. For more information, including how to disable this warning, see https://deprecations.emberjs.com/v1.x/#toc_binding-style-attributes.