### PR TITLE
feat: change banner ID patterns used for dismissal

### DIFF
--- a/javascripts/discourse/api-initializers/notification-banners.gjs
+++ b/javascripts/discourse/api-initializers/notification-banners.gjs
@@ -61,10 +61,11 @@ function normalizeName(outlet) {
 
 function slugify(str) {
   str = str
+    .trim() // trim leading/trailing white space
     .replace(/[^a-zA-Z0-9 -]/g, "") // remove any non-alphanumeric characters
     .replace(/\s+/g, "-") // replace spaces with hyphens
     .replace(/-+/g, "-") // remove consecutive hyphens
-    .replace(/^\s+|\s+$/g, ""); // trim leading/trailing white space
+    .padEnd(6, "0");
   return str;
 }
 

--- a/javascripts/discourse/api-initializers/notification-banners.gjs
+++ b/javascripts/discourse/api-initializers/notification-banners.gjs
@@ -62,14 +62,16 @@ function normalizeName(outlet) {
 export default apiInitializer((api) => {
   loadSplideCSS();
 
-  const banners = [...settings.banners].reduce((acc, banner, index) => {
+  const bannerConfigVersion = settings.banner_config_version;
+
+  const banners = [...settings.banners].reduce((acc, banner) => {
     const outlet = banner.plugin_outlet;
     const type = banner.carousel ? "carousel" : "solo";
 
     // Create new object instead of mutating
     const processedBanner = {
       ...banner,
-      id: `notification-banner--${index}--${outlet}`,
+      id: `notification-banner--${banner.id}--${bannerConfigVersion}`,
       styles: bannerStyles(banner.background_color),
     };
 

--- a/javascripts/discourse/api-initializers/notification-banners.gjs
+++ b/javascripts/discourse/api-initializers/notification-banners.gjs
@@ -59,6 +59,15 @@ function normalizeName(outlet) {
   return outlet.replaceAll("-", "_");
 }
 
+function slugify(str) {
+  str = str
+    .replace(/[^a-zA-Z0-9 -]/g, "") // remove any non-alphanumeric characters
+    .replace(/\s+/g, "-") // replace spaces with hyphens
+    .replace(/-+/g, "-") // remove consecutive hyphens
+    .replace(/^\s+|\s+$/g, ""); // trim leading/trailing white space
+  return str;
+}
+
 export default apiInitializer((api) => {
   loadSplideCSS();
 
@@ -71,7 +80,7 @@ export default apiInitializer((api) => {
     // Create new object instead of mutating
     const processedBanner = {
       ...banner,
-      id: `notification-banner--${banner.id}--${bannerConfigVersion}`,
+      id: `notification-banner--${slugify(banner.id)}--${bannerConfigVersion}`,
       styles: bannerStyles(banner.background_color),
     };
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -8,7 +8,7 @@ en:
           properties:
             id:
               label: Banner ID
-              description: "A unique identifier for the banner (6 characters max). Used for dismissed banners."
+              description: "A unique identifier for the banner. Used for dismissed banners.<br>6 characters; only a-z, A-Z, 0-9, and hyphens."
             enabled_groups:
               label: Audience
               description: "Select which user groups can see this banner. You must select at least one group.\n\n <b>To show to all users and visitors:</b> Select the <code>everyone</code> group.\n\n <b>Important note on Trust Levels:</b> Selecting a Trust Level (e.g., <code>trust_level_3</code>) will show the banner <b>only</b> to users at that exact level. It does not include users at higher or lower levels."

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -6,6 +6,9 @@ en:
         description: Add notification banners to your site
         schema:
           properties:
+            id:
+              label: Banner ID
+              description: "A unique identifier for the banner (6 characters max). Used for dismissed banners."
             enabled_groups:
               label: Audience
               description: "Select which user groups can see this banner. You must select at least one group.\n\n <b>To show to all users and visitors:</b> Select the <code>everyone</code> group.\n\n <b>Important note on Trust Levels:</b> Selecting a Trust Level (e.g., <code>trust_level_3</code>) will show the banner <b>only</b> to users at that exact level. It does not include users at higher or lower levels."

--- a/migrations/settings/0004-add-id.js
+++ b/migrations/settings/0004-add-id.js
@@ -1,0 +1,36 @@
+export default function migrate(settings) {
+  const addId = (bannerList) => {
+    const prefixMap = {
+      "top-notices": "TN",
+      "above-site-header": "AH",
+      "below-site-header": "BH",
+    };
+
+    const counters = {};
+
+    return bannerList.map((banner) => {
+      const outlet = banner.plugin_outlet;
+      const prefix = prefixMap[outlet];
+
+      if (!counters[outlet]) {
+        counters[outlet] = 0;
+      }
+
+      counters[outlet]++;
+      const id = `${prefix}-${counters[outlet].toString().padStart(3, "0")}`;
+
+      return {
+        id,
+        ...banner,
+      };
+    });
+  };
+
+  if (settings.has("banners")) {
+    const banners = settings.get("banners");
+    const updatedBanners = addId(banners);
+
+    settings.set("banners", updatedBanners);
+  }
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -4,8 +4,14 @@ banners:
   type: objects
   schema:
     name: Banner message
-    identifier: title
+    identifier: id
     properties:
+      id:
+        type: string
+        required: true
+        validations:
+          min_length: 6
+          max_length: 6
       enabled_groups:
         type: groups
         required: true
@@ -41,18 +47,29 @@ banners:
       date_before:
         type: string
 
+banner_config_version:
+  type: string
+  default: "2025-11-04"
+  min: 3
+  max: 15
+  description: "When important changes are made to the banners, you must change this value to reset the banner visibility. This change ensures all your users see previously dismissed banners."
+  refresh: true
+
 splide_options__above_site_header:
   type: string
   default: "{ \"autoHeight\": true, \"height\": \"8rem\", \"arrows\": false, \"autoplay\": true, \"direction\": \"ttb\", \"focus\": \"center\", \"gap\": 0, \"type\": \"loop\" }"
   description: "<a href=\"https://splidejs.com/guides/options/\" target=\"_blank\">Splide options</a> for banners above the site header"
+  textarea: true
   refresh: true
 splide_options__below_site_header:
   type: string
   default: "{ \"autoHeight\": true, \"height\": \"8rem\", \"arrows\": false, \"autoplay\": true, \"direction\": \"ttb\", \"focus\": \"center\", \"gap\": 0, \"type\": \"loop\" }"
   description: "<a href=\"https://splidejs.com/guides/options/\" target=\"_blank\">Splide options</a> for banners below the site header"
+  textarea: true
   refresh: true
 splide_options__top_notices:
   type: string
   default: "{ \"autoHeight\": true, \"height\": \"8rem\", \"arrows\": false, \"autoplay\": true, \"direction\": \"ttb\", \"focus\": \"center\", \"gap\": 0, \"type\": \"loop\" }"
   description: "<a href=\"https://splidejs.com/guides/options/\" target=\"_blank\">Splide options</a> for banners in top notices"
+  textarea: true
   refresh: true

--- a/spec/system/notification_banners_spec.rb
+++ b/spec/system/notification_banners_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Test Banner",
@@ -46,6 +47,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Dismiss Me",
@@ -76,6 +78,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Future Banner",
@@ -103,6 +106,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [group.id],
             "selected_categories" => [],
             "title" => "Group Banner",
@@ -136,6 +140,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [category.id],
             "title" => "Category Banner",
@@ -167,6 +172,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Carousel One",
@@ -179,6 +185,7 @@ RSpec.describe "Notification Banners", system: true do
             "date_before" => "",
           },
           {
+            "id" => "AH-002",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Carousel Two",
@@ -209,6 +216,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Single Carousel",
@@ -238,6 +246,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Above Header",
@@ -250,6 +259,7 @@ RSpec.describe "Notification Banners", system: true do
             "date_before" => "",
           },
           {
+            "id" => "BH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Below Header",
@@ -262,6 +272,7 @@ RSpec.describe "Notification Banners", system: true do
             "date_before" => "",
           },
           {
+            "id" => "TN-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Top Notices",
@@ -292,6 +303,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "No Admin",
@@ -320,6 +332,7 @@ RSpec.describe "Notification Banners", system: true do
         :banners,
         [
           {
+            "id" => "AH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Dark BG",
@@ -332,6 +345,7 @@ RSpec.describe "Notification Banners", system: true do
             "date_before" => "",
           },
           {
+            "id" => "BH-001",
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Light BG",


### PR DESCRIPTION
This pull request introduces a unique, required `id` field for each notification banner and updates related settings, migration logic, and tests to support this change. Additionally, it adds a `banner_config_version` setting to help reset banner visibility for users when important changes occur. These improvements ensure that banner dismissal tracking is more robust and future-proof.

**Banner ID system and migration:**

* Added a required `id` property to each banner in `settings.yml`, enforced to be exactly 6 characters, and updated the schema identifier to use `id` instead of `title`.
* Implemented a migration script (`0004-add-id.js`) that automatically generates unique IDs for existing banners based on their outlet, ensuring backward compatibility.

**Banner configuration and tracking:**

* Updated the banner rendering logic to use the new `id` and `banner_config_version` for banner identification and dismissal tracking, including a new `slugify` helper for ID formatting.
* Introduced the `banner_config_version` setting in `settings.yml`, which must be changed to reset banner dismissal for all users after significant banner changes.

**Documentation and tests:**

* Updated English locale documentation to describe the new `id` field and its role in banner dismissal.
* Modified all relevant system specs to include the new `id` field for each banner, ensuring tests reflect the updated schema and logic. [[1]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R20) [[2]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R50) [[3]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R81) [[4]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R109) [[5]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R143) [[6]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R175) [[7]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R188) [[8]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R219) [[9]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R249) [[10]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R262) [[11]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R275) [[12]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R306) [[13]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R335) [[14]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39R348)