### PR TITLE
chore: fix typo for dismissible

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Each notification banner may have the following features:
 * **Background color**, can be set to differantiate the banner from others.
 * **Plugin outlet**, set notifications above or below the site header, or use the top-notices outlet to display along with native topic banners.
 * **Display in a carousel**, when selected, all the banners in each outlet are displayed in a carousel. Requires minimum 2 banners to be selected for any outlet.
-* **Dismissable**, when selected, the users will be able to dismiss the banner, and it will be hidden for them.
+* **Dismissible**, when selected, the users will be able to dismiss the banner, and it will be hidden for them.
 * **Starting and Last dates**, when defined, banner's visibility obeys to those dates. So you can set a banner in advance, but it will become visible to selected audience only on set date and time; or similarly you can automatically remove the banner by the last date it should show.
 * **Display order**, define which banner should be displayed top, which should be at bottom.
 

--- a/javascripts/discourse/components/notification-banner.gjs
+++ b/javascripts/discourse/components/notification-banner.gjs
@@ -7,13 +7,13 @@ import DButton from "discourse/components/d-button";
 
 export default class NotificationBanner extends Component {
   @tracked
-  dismissed = this.args.banner.dismissable
+  dismissed = this.args.banner.dismissible
     ? localStorage.getItem(this.args.banner.id)
     : false;
 
   @action
   dismiss() {
-    if (!this.args.banner.dismissable) {
+    if (!this.args.banner.dismissible) {
       return;
     }
     this.dismissed = true;
@@ -32,7 +32,7 @@ export default class NotificationBanner extends Component {
         style={{htmlSafe @banner.styles}}
       >
         <div class="notification-banner__wrapper wrap">
-          {{#if @banner.dismissable}}
+          {{#if @banner.dismissible}}
             <div class="notification-banner__close">
               <DButton
                 @icon="xmark"

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -30,7 +30,7 @@ en:
             carousel:
               label: Display in a Carousel
               description: "Enables a carousel for all the banners in the same plugin outlet. When left unchecked, the banner will be displayed as a stack."
-            dismissable:
+            dismissible:
               label: Dismissible
               description: "Allow users to dismiss the banner by closing it.\nNote: When \"caraousel\" is enabled, this setting will be ignored."
             date_after:

--- a/migrations/settings/0006-fix-typo.js
+++ b/migrations/settings/0006-fix-typo.js
@@ -1,12 +1,19 @@
 export default function migrate(settings) {
-  if (settings.has("banners")) {
-    const banners = settings.get("banners");
-    banners.forEach((banner) => {
-      banner.dismissible = banner.dismissable;
-      delete banner.dismissable;
-    });
-
-    settings.set("banners", banners);
+  if (!settings.has("banners")) {
+    return settings;
   }
+
+  const banners = settings.get("banners");
+  const updated = banners.map((banner) => {
+    const dismissible = banner.dismissable ?? false;
+    delete banner.dismissable;
+
+    return {
+      ...banner,
+      dismissible,
+    };
+  });
+
+  settings.set("banners", updated);
   return settings;
 }

--- a/migrations/settings/0006-fix-typo.js
+++ b/migrations/settings/0006-fix-typo.js
@@ -1,0 +1,12 @@
+export default function migrate(settings) {
+  if (settings.has("banners")) {
+    const banners = settings.get("banners");
+    banners.forEach((banner) => {
+      banner.dismissible = banner.dismissable;
+      delete banner.dismissable;
+    });
+
+    settings.set("banners", banners);
+  }
+  return settings;
+}

--- a/settings.yml
+++ b/settings.yml
@@ -40,7 +40,7 @@ banners:
           - "top-notices"
       carousel:
         type: boolean
-      dismissable:
+      dismissible:
         type: boolean
       date_after:
         type: datetime

--- a/spec/system/notification_banners_spec.rb
+++ b/spec/system/notification_banners_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "ff0000",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => true,
+            "dismissible" => true,
             "date_after" => "",
             "date_before" => "",
           },
@@ -41,7 +41,7 @@ RSpec.describe "Notification Banners", system: true do
     end
   end
 
-  context "when a notification banner is dismissable" do
+  context "when a notification banner is dismissible" do
     before do
       theme_component.update_setting(
         :banners,
@@ -51,11 +51,11 @@ RSpec.describe "Notification Banners", system: true do
             "enabled_groups" => [0],
             "selected_categories" => [],
             "title" => "Dismiss Me",
-            "message" => "Dismissable banner",
+            "message" => "Dismissible banner",
             "background_color" => "00ff00",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => true,
+            "dismissible" => true,
             "date_after" => "",
             "date_before" => "",
           },
@@ -66,9 +66,9 @@ RSpec.describe "Notification Banners", system: true do
 
     it "should allow dismissing the banner" do
       visit "/"
-      expect(page).to have_css(".notification-banner", text: "Dismissable banner")
+      expect(page).to have_css(".notification-banner", text: "Dismissible banner")
       find(".notification-banner__close .close").click
-      expect(page).to have_no_css(".notification-banner", text: "Dismissable banner")
+      expect(page).to have_no_css(".notification-banner", text: "Dismissible banner")
     end
   end
 
@@ -86,7 +86,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "0000ff",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => 1.day.from_now.iso8601,
             "date_before" => 2.days.from_now.iso8601,
           },
@@ -114,7 +114,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "123456",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -148,7 +148,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "abcdef",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -180,7 +180,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "111111",
             "plugin_outlet" => "above-site-header",
             "carousel" => true,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -193,7 +193,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "222222",
             "plugin_outlet" => "above-site-header",
             "carousel" => true,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -224,7 +224,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "333333",
             "plugin_outlet" => "above-site-header",
             "carousel" => true,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -254,7 +254,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "444444",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -267,7 +267,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "555555",
             "plugin_outlet" => "below-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -280,7 +280,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "666666",
             "plugin_outlet" => "top-notices",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -311,7 +311,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "777777",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -340,7 +340,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "000000",
             "plugin_outlet" => "above-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },
@@ -353,7 +353,7 @@ RSpec.describe "Notification Banners", system: true do
             "background_color" => "FFFFFF",
             "plugin_outlet" => "below-site-header",
             "carousel" => false,
-            "dismissable" => false,
+            "dismissible" => false,
             "date_after" => "",
             "date_before" => "",
           },


### PR DESCRIPTION
This pull request standardizes the spelling of the "dismissible" property for notification banners throughout the codebase, replacing the incorrect "dismissable" variant. It updates all relevant documentation, configuration, settings, and tests to use the correct spelling, and includes a migration script to convert any existing data to the new property name.

Key changes include:

**Property and Configuration Renaming:**

* Renamed all instances of the `dismissable` property to `dismissible` in the banner settings schema (`settings.yml`), English locale strings (`locales/en.yml`), and documentation (`README.md`). [[1]](diffhunk://#diff-6167ce9ac9bedafca7114a29ba4fba1ad953b7e6006a3dff08e3272c1866128bL43-R43) [[2]](diffhunk://#diff-847d4476f4d777f46cf45f4b203b31c3c98a7ff363ba122ac5bd8c256f1f38d2L33-R33) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L34-R34)

**Migration Script:**

* Added a migration (`migrations/settings/0006-fix-typo.js`) to automatically convert existing `dismissable` properties to `dismissible` in stored banner settings, ensuring backward compatibility.

**Test Updates:**

* Updated all references to `dismissable` in the system specs for notification banners to `dismissible`, including test data, context descriptions, and assertions. [[1]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L28-R28) [[2]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L44-R44) [[3]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L54-R58) [[4]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L69-R71) [[5]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L89-R89) [[6]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L117-R117) [[7]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L151-R151) [[8]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L183-R183) [[9]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L196-R196) [[10]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L227-R227) [[11]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L257-R257) [[12]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L270-R270) [[13]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L283-R283) [[14]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L314-R314) [[15]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L343-R343) [[16]](diffhunk://#diff-769b9b5fe98b17d8d2fc72d53ededb823297df3ddca4cb6d18efe2c704644e39L356-R356)